### PR TITLE
Add some outlines of sending errors as webhooks

### DIFF
--- a/content/standard/webhook-error-notifications.md
+++ b/content/standard/webhook-error-notifications.md
@@ -1,0 +1,23 @@
+---
+title: "Webhook Error Notifications"
+date: 2011-11-22T11:15:27+01:00
+severity: should
+category: callbacks
+example_apis: []
+---
+
+### Webhooks as Error Notifications
+
+When sending error information as a webhook, these are our standard fields.
+
+* `reason` (**required**): Description of the error
+* `timestamp` (**required**): Timestamp in ISO 8601 format
+* `level` (**recommended**): One of "error", "warn" or "info" - if this field is omitted, "error" should be assumed (the Voice API originally only had one error level).
+* `type`: A URL to more information about the error (as used in Response Errors)
+* `detail`: Any more information about the error (as used in Response Errors)
+
+In addition, any other identifiers or other information that are useful in the error context. For example, Voice API also returns `conversation_uuid`.
+
+#### Notes
+
+Standard field naming guidelines for webhooks also apply.

--- a/content/standard/webhook-error-notifications.md
+++ b/content/standard/webhook-error-notifications.md
@@ -12,8 +12,8 @@ When sending error information as a webhook, these are our standard fields.
 
 * `reason` (**required**): Description of the error
 * `timestamp` (**required**): Timestamp in ISO 8601 format
-* `level` (**recommended**): One of "error", "warn" or "info" - if this field is omitted, "error" should be assumed (the Voice API originally only had one error level).
-* `type`: A URL to more information about the error (as used in Response Errors)
+* `level` (**required**): One of "error", "warn" or "info" - if this field is omitted, "error" should be assumed (the Voice API originally only had one error level).
+* `type` (**required**): A URL to more information about the error (as used in Response Errors)
 * `detail`: Any more information about the error (as used in Response Errors)
 
 In addition, any other identifiers or other information that are useful in the error context. For example, Voice API also returns `conversation_uuid`.

--- a/content/standard/webhooks.md
+++ b/content/standard/webhooks.md
@@ -6,9 +6,27 @@ category: callbacks
 example_apis: []
 ---
 
-### GET webhooks
+### Delivering Data with a Webhook
 
-Objects *retrieved* via webhooks by the API are in `camelCase`.
+`POST` is our preferred method when delivering data via webhook.
+
+Objects and data *sent* via webhooks by the API are in `snake_case`.
+
+#### Examples
+
+[Voice API webhooks](https://developer.nexmo.com/voice/voice-api/webhook-reference)
+
+* `conversation_uuid`
+* `start_time`
+
+[Messages API callbacks](https://developer.nexmo.com/api/messages-olympus#inbound-message)
+
+* `message_uuid`
+* `timestamp`
+
+### Webhooks to Fetch Data
+
+There may be some use cases when the webhook fetches data and causes no effect on the receiving side. In this case, `GET` method may be used and `camelCase` variables may be preferred for consistency with other parts of the application.
 
 #### Examples
 
@@ -17,17 +35,6 @@ Nexmo Call Control Objects ([NCCO](https://developer.nexmo.com/voice/voice-api/n
 * `eventUrl`
 * `musicOnHold`
 * `beepOnStart`
-
-### POST webhooks
-
-Objects *sent* via webhooks by the API are in `snake_case`.
-
-#### Examples
-
-[Voice API callbacks](https://developer.nexmo.com/voice/voice-api/webhook-reference)
-
-* `conversation_uuid`
-* `start_time`
 
 ### Why did we choose this?
 


### PR DESCRIPTION
Relating to https://github.com/Nexmo/nexmo-developer/pull/2067, this PR attempts to capture the current approach to errors arriving as webhook events.