### PR TITLE
HAL links must respect the Host header of inbound requests

### DIFF
--- a/content/standard/hal-json.md
+++ b/content/standard/hal-json.md
@@ -16,6 +16,8 @@ This is a short description of the standard
 * There will always be a `_links.self` to the current resource.
 * Paging will use `_links`.
 
+> *Important:* The base URL in the `_links` section must reflect the host used for the incoming request. If the user calls `https://api-eu-1.nexmo.com` then the base URL for any `href` fields in `_links` must be the same (unless there are technical limitations why we must use `https://api.nexmo.com`)
+
 ### Examples
 
 ```json


### PR DESCRIPTION
Related to [this slack conversation](https://vonage.slack.com/archives/CG3JYU7SR/p1565186684050600)

The `Host` header should be respected for inbound requests. Using the global API host is acceptable if there is a technical reason not to provide the regional endpoint

---


Listing a user a-la https://api-eu-1.nexmo.com/beta/users, returns a list of users like

```
[
    {
        "id": "USR-0f7769c7-e47b-44a0-a7ac-ff2ad84b92d8",
        "name": "11128279_321321",
        "href": "https://api.nexmo.com/beta/users/USR-0f7769c7-e47b-44a0-a7ac-ff2ad84b92d8"
    },
```

But if I try and delete that user via https://api.nexmo.com/beta/users/USR-0f7769c7-e47b-44a0-a7ac-ff2ad84b92d8 it is not found, the delete needs to be https://api-eu-1.nexmo.com/beta/users/USR-0f7769c7-e47b-44a0-a7ac-ff2ad84b92d8