### PR TITLE
Allow multiple underscores in field/property names

### DIFF
--- a/content/standard/property-names.md
+++ b/content/standard/property-names.md
@@ -9,14 +9,13 @@ example_apis: []
 - Have parameters / properties in lower case with underscores. 
 - Have identifiers following the format: type_id. (message_id, recording_id, etc)
 - Use distinguishers only when the name is non-intuitive or conflicts with another name. (`count` instead of `message_count` because message should be intuitive, but `carrier_network` if there's also a roaming network)
-- Limit parameter / property names to a single underscore.
 - Reuse parameter / property names. (`from` instead of `msisdn`)
 
 ### Examples
 
 - `machine_detection`
 - `call_id`
-- `conference_id`
+- `balance_transfer_id`
 
 ### Why did we choose this?
 


### PR DESCRIPTION
Our existing standards state that all property names should use underscores and no more than one underscore (see https://nexmo.github.io/api-standards/standard/property-names/). This PR removes the restriction on the number of underscores and also adds an example with more than one to make it clear.