### PR TITLE
Add guidelines for datetime fields

### DIFF
--- a/content/standard/data-structure.md
+++ b/content/standard/data-structure.md
@@ -20,8 +20,8 @@ We aim to use consistent terminology across all APIs. Here are the commonly used
 * `count` - The number of parts your message was divided into in order to be sent correctly.
 * `total` - The amount of objects found as a result of a search request.
 * `direction` - Inbound (MO) or Outbound (MT)
-* `start` - The time the communication started in https://en.wikipedia.org/wiki/ISO_8601 format.
-* `end` - The time the communication ended in https://en.wikipedia.org/wiki/ISO_8601 format.
+* `started_at` - The time the communication started in https://en.wikipedia.org/wiki/ISO_8601 format.
+* `ended_at` - The time the communication ended in https://en.wikipedia.org/wiki/ISO_8601 format.
 * `duration` - The duration of the call in seconds.
 * `balance` - The amount of money left in your Nexmo account.
 * `rate` - The price for each request. This is per request for text based messages, or per second for voice.

--- a/content/standard/dates-and-times.md
+++ b/content/standard/dates-and-times.md
@@ -6,7 +6,7 @@ category: properties
 example_apis: []
 ---
 
-When working with dates, our APIs will use consistent naming and formats.
+When working with dates, our APIs use consistent naming and formats.
 
 Field names should be `[something]_at`. Examples include:
 
@@ -14,7 +14,7 @@ Field names should be `[something]_at`. Examples include:
 * `started_at`
 * `last_event_at`
 
-The format will be [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard, for example: `2020-02-21T14:43:23+00:00` _or_ `2020-02-21T14:43:23Z`.
+The format will be [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard, for example: `2020-02-21T14:43:23+00:00`.
 
 ### Examples
 

--- a/content/standard/dates-and-times.md
+++ b/content/standard/dates-and-times.md
@@ -1,0 +1,34 @@
+---
+title: "Dates and Times"
+date: 2020-02-21T14:15:43+01:00
+severity: should
+category: properties
+example_apis: []
+---
+
+When working with dates, our APIs will use consistent naming and formats.
+
+Field names should be `[something]_at`. Examples include:
+
+* `created_at`
+* `started_at`
+* `last_event_at`
+
+The format will be [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard, for example: `2020-02-21T14:43:23+00:00` _or_ `2020-02-21T14:43:23Z`.
+
+### Examples
+
+```json
+{
+  "created_at": "2020-02-21T14:43:23+00:00"
+}
+```
+
+### Why did we choose this?
+
+Sugested and discussed in the #api-standards channel before adoption for future APIs.
+
+### Related Links
+
+* [Wikipedia ISO 8601 page](https://en.wikipedia.org/wiki/ISO_8601) for more information about the format and examples
+* Also used by [GitHub's API](https://developer.github.com/v3/#schema)

--- a/content/standard/property-names.md
+++ b/content/standard/property-names.md
@@ -16,6 +16,7 @@ example_apis: []
 - `machine_detection`
 - `call_id`
 - `balance_transfer_id`
+- `received_at`
 
 ### Why did we choose this?
 


### PR DESCRIPTION
A new page to describe our approach to datetime values. Includes naming, format (ISO 8601) and examples.﻿
