### PR TITLE
Guidelines on expected status and response for each operation

### DIFF
--- a/content/http-code/200.md
+++ b/content/http-code/200.md
@@ -13,7 +13,7 @@ The `200` HTTP code is used when the user's request has been successful. This is
 {
   "_links": {
     "self": {
-      "href": "/accounts/7c9738e6/secrets"
+      "href": "https://api.nexmo.com/accounts/7c9738e6/secrets"
     }
   },
   "_embedded": {
@@ -21,7 +21,7 @@ The `200` HTTP code is used when the user's request has been successful. This is
       {
         "_links": {
           "self": {
-            "href": "/accounts/7c9738e6/secrets/ad6dc56f-07b5-46e1-a527-85530e625800"
+            "href": "https://api.nexmo.com/accounts/7c9738e6/secrets/ad6dc56f-07b5-46e1-a527-85530e625800"
           }
         },
         "id": "ad6dc56f-07b5-46e1-a527-85530e625800",

--- a/content/http-code/201.md
+++ b/content/http-code/201.md
@@ -7,7 +7,7 @@ date: 2018-07-31T00:45:40+01:00
 
 Used when a new resource has been created. 
 
-According to the HTTP specification, this should contain a `Location` header pointing to the created resource. In general Nexmo APIs don't do this, instead opting to return the `GET` representation in the response
+The body of the response should be the same as the `GET` representation of the new resource, including any generated/calculated fields.
 
 ## Example response
 
@@ -15,7 +15,7 @@ According to the HTTP specification, this should contain a `Location` header poi
 {
   "_links": {
     "self": {
-      "href": "/accounts/7c9738e6/secrets/ad6dc56f-07b5-46e1-a527-85530e625800"
+      "href": "https://api.nexmo.com/accounts/7c9738e6/secrets/ad6dc56f-07b5-46e1-a527-85530e625800"
     }
   },
   "id": "ad6dc56f-07b5-46e1-a527-85530e625800",

--- a/content/http-code/202.md
+++ b/content/http-code/202.md
@@ -5,14 +5,17 @@ date: 2018-07-31T02:25:26+01:00
 
 # 202
 
-Acknowledges the request has been received, but not that the process has been completed. Used for asynchronous tasks. Response body should include some kind of status, and a way to poll for status.  Should avoid this in favor of creating a 'workflow' resource for anything complex.
+Acknowledges the request has been received, but not that the process has been completed. Used for asynchronous tasks, such as if the action will be placed in a queue, or depends on an external service with a slow response time.
+
+The response body should include status information and an identifier for the resource, such as a `self` link (some of our APIs return an ID here which is also acceptable).
 
 ## Example response
 
-> @TODO: Improve this example response
-
 ```json
 {
-  "status":"accepted"
+  _links: {
+    "self": "https://example.com/things/aaaaaaaa-bbbb-cccc-dddd-0123456789ab"
+  }
+  submitted_at: 2020-01-02T03:04:00+01:00
 }
 ```

--- a/content/standard/http-verbs.md
+++ b/content/standard/http-verbs.md
@@ -8,9 +8,9 @@ example_apis: []
 
 - Use HTTP methods appropriately for the operation you are performing. CRUD (Create, Read, Update, Delete) operations and the correct response for each are as follows:
   - GET lists Resources in a Collection, or a single Resource, returning a [200 status](/api-standards/http-code-200) and the requested Resource(s)
-  - POST creates a new Resource in a Collection, returning a [201 status](/api-standards/http-code/201) and the new Resource
-  - PUT replaces a complete Resource with the supplied representation, returning a [200 status](/api-standards/http-code-200) and the udpated Resource
-  - PATCH partially updates a Resource with the supplied fields, returning a [200 status](/api-standards/http-code-200) and the udpated Resource
+  - POST creates a new Resource in a Collection, returning a [201 status](/api-standards/http-code/201) and the new Resource if it is available. For a Resource that is not synchronously created, a [202 status](/api-standards/http-code/202) and as much information as is currently available should be returned; usually there will be a callback to deliver the Resource once it is available.
+  - PUT replaces a complete Resource with the supplied representation, returning a [200 status](/api-standards/http-code-200) and the updated Resource
+  - PATCH partially updates a Resource with the supplied fields, returning a [200 status](/api-standards/http-code-200) and the updated Resource
   - DELETE removes a Resource, returning a [204 status](/api-standards/http-code/204) status and no body
 
 ### Examples

--- a/content/standard/http-verbs.md
+++ b/content/standard/http-verbs.md
@@ -6,12 +6,12 @@ category: request
 example_apis: []
 ---
 
-- Use HTTP methods to map CRUD actions on Resources i.e. 
-  - POST creates a new Resources in a Collection (see also [201 status](/api-standards/http-code/201) )
-  - DELETE removes a Resource
-  - GET lists Resources
-  - PUT replaces a complete Resource
-  - PATCH partially updates a Resource
+- Use HTTP methods appropriately for the operation you are performing. CRUD (Create, Read, Update, Delete) operations and the correct response for each are as follows:
+  - GET lists Resources in a Collection, or a single Resource, returning a [200 status](/api-standards/http-code-200) and the requested Resource(s)
+  - POST creates a new Resource in a Collection, returning a [201 status](/api-standards/http-code/201) and the new Resource
+  - PUT replaces a complete Resource with the supplied representation, returning a [200 status](/api-standards/http-code-200) and the udpated Resource
+  - PATCH partially updates a Resource with the supplied fields, returning a [200 status](/api-standards/http-code-200) and the udpated Resource
+  - DELETE removes a Resource, returning a [204 status](/api-standards/http-code/204) status and no body
 
 ### Examples
 
@@ -28,4 +28,6 @@ Pre-existing standard
 
 ### Related Links
 
-* [RFC2616](https://tools.ietf.org/html/rfc2616#section-9)
+* The [Method Definitions in the RFC2616 HTTP 1.1 spec](https://tools.ietf.org/html/rfc2616#section-9) are relevant to this part of API design.
+* For the not-so-happy path, there are [error format guidelines](/api-standards/standard/errors) to guide you.
+* All responses should follow [HAL-JSON format](/api-standards/standard/hal-json).

--- a/content/standard/http-verbs.md
+++ b/content/standard/http-verbs.md
@@ -7,7 +7,7 @@ example_apis: []
 ---
 
 - Use HTTP methods to map CRUD actions on Resources i.e. 
-  - POST creates a new Resources in a Collection
+  - POST creates a new Resources in a Collection (see also [201 status](/api-standards/http-code/201) )
   - DELETE removes a Resource
   - GET lists Resources
   - PUT replaces a complete Resource


### PR DESCRIPTION
Update the guidelines to mention our preferred approach of returning a resource with the 201 on create, rather than the more standard redirect header. Outline statuses and responses for the other operations too.

Also make the example URLs absolute.﻿
